### PR TITLE
adds basic style to form in space#new-view

### DIFF
--- a/app/views/spaces/new.html.erb
+++ b/app/views/spaces/new.html.erb
@@ -5,17 +5,17 @@
       <h3>Offer your Office to Fellow Co-Workers</h3>
       <br>
       <br>
-      <%= simple_form_for(@space) do |f| %>
-        <%= f.input :title %>
-        <%= f.input :description %>
-        <%= f.input :space_type, as: :radio_buttons, collection: ['Private Space', 'Community Space', 'Corporate Space', 'Professionial Space'] %>
-        <%= f.input :price_per_month %>
-        <%= f.input :location %>
-        <%= f.input :photo, as: :file %>
-        <br>
-        <%= f.submit 'Create HUB', class: 'create btn btn-warning', style: "margin-right: 10px; border-radius: 50px" %>
-        <%= link_to 'Back Home', root_path, class: 'btn btn-outline-dark', style: "margin-right: 10px; border-radius: 50px" %>
-      <% end %>
+        <%= simple_form_for @space, remote: true do |f| %>
+          <%= f.input :title, wrapper: :field4  %>
+          <%= f.input :description, wrapper: :field8 %>
+          <%= f.input :space_type, as: :radio_buttons, collection: ['Private Space', 'Community Space', 'Corporate Space', 'Professionial Space'] %>
+          <%= f.input :price_per_month, wrapper: :field4 %>
+          <%= f.input :location, wrapper: :field4 %>
+          <%= f.input :photo, as: :file %>
+          <br>
+          <%= f.submit 'Create HUB', class: 'create btn btn-warning', style: "margin-right: 10px; border-radius: 50px" %>
+          <%= link_to 'Back Home', root_path, class: 'btn btn-outline-dark', style: "margin-right: 10px; border-radius: 50px" %>
+        <% end %>
     </div>
   </div>
 </div>

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -4,7 +4,7 @@
 # components.
 # See https://github.com/heartcombo/simple_form#custom-components to know
 # more about custom components.
-# Dir[Rails.root.join('lib/components/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('lib/components/**/*.rb')].each { |f| require f }
 #
 # Use this setup block to configure all options available in SimpleForm.
 SimpleForm.setup do |config|
@@ -173,4 +173,32 @@ SimpleForm.setup do |config|
   # Defines validation classes to the input_field. By default it's nil.
   # config.input_field_valid_class = 'is-valid'
   # config.input_field_error_class = 'is-invalid'
+
+  config.wrappers :with_numbers, tag: 'div', class: 'row', error_class: 'error' do |b|
+    b.use :html5
+    b.use :number, wrap_with: { tag: 'div', class: 'span1 number'}
+    b.wrapper tag: 'div', class: 'span8' do |ba|
+      ba.use :placeholder
+      ba.use :label
+      ba.use :input
+      ba.use :error, wrap_with: { tag: 'span', class: 'help-inline' }
+      ba.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+    end
+  end
+
+  1.upto(12) do |col|
+    config.wrappers "field#{col}".to_sym, tag: 'div', class: 'form-group', error_class: 'has-error' do |mdf|
+      mdf.use :html5
+      mdf.use :placeholder
+      mdf.use :label, class: 'sr-only'
+  
+      mdf.wrapper tag: 'div', class: "col-sm-#{col}" do |wr|
+        wr.use :input, class: 'form-control'
+        wr.use :error, wrap_with: { tag: 'span', class: 'help-block' }
+        wr.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
+      end
+    end
+  end
+
+
 end

--- a/lib/components/numbers_component.rb
+++ b/lib/components/numbers_component.rb
@@ -1,0 +1,11 @@
+module NumbersComponent
+    # To avoid deprecation warning, you need to make the wrapper_options explicit
+    # even when they won't be used.
+    def number(wrapper_options = nil)
+      @number ||= begin
+        options[:number].to_s.html_safe if options[:number].present?
+      end
+    end
+  end
+  
+  SimpleForm.include_component(NumbersComponent)


### PR DESCRIPTION
The following suggests changes to have a less messy html-tag view and improved simple-form usage.

- tells simple form to find changes in # config/initializers/simple_form.rb
- adds 2 wrappers  to # config/initializers/simple_form.rb ("numbers" and "field")
- creates new number component in lib/components/numbers_component.rb

Takes wrapper - suggestions from here: 
     https://almassapargali.com/2015/01/15/build-bootstrap-forms-with-simple_form-in-ruby-on-rails.html

See documentation of simple form to better understand changes:
https://github.com/heartcombo/simple_form